### PR TITLE
Update docker compose example with sound devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ services:
     environment: 
       - HOST=host.docker.internal
       - FORMAT=-r 44100 -f S16_LE -c 2
-    ports:
-      - 8888:8888
+    network_mode: host
     volumes:
       - ./ledfx-config:/root/.ledfx
       - ~/audio:/app/audio
+    devices:
+      - /dev/snd:/dev/snd
 ```
 ### Volumes
 Volume | Function 


### PR DESCRIPTION
This is the docker-compose configuration that I'm using which allows for network discovery of WLED as well as use of sound hardware from the host machine. It may be the older way of redirecting audio using a patch cable rather than snapcast, but it works for me.